### PR TITLE
[44기 장다희][ADD] products 리스트 - 정렬 기능 추가

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -8,13 +8,15 @@ const productSearch = catchAsync(async (req, res) => {
 });
 
 const getProducts = catchAsync(async (req, res) => {
-  const { subid, mainid, pid, ismain } = req.query;
+  const { subid, mainid, pid, ismain, orderby, sorting } = req.query;
 
   const products = await productService.getProductsByCondition(
     subid,
     mainid,
     pid,
-    ismain
+    ismain,
+    orderby,
+    sorting
   );
   res.status(200).json(products);
 });

--- a/models/productDao.js
+++ b/models/productDao.js
@@ -1,8 +1,8 @@
-const appdataSource = require('./appDataSource');
+const appDataSource = require('./appDataSource');
 
 const searchProduct = async (keyword) => {
   try {
-    return appdataSource.query(
+    return appDataSource.query(
       `SELECT 
       products.id,
       products.name,
@@ -20,7 +20,14 @@ const searchProduct = async (keyword) => {
   }
 };
 
-const getProductsByCondition = async (subId, mainId, pId, isMain) => {
+const getProductsByCondition = async (
+  subId,
+  mainId,
+  pId,
+  isMain,
+  orderBy,
+  sorting
+) => {
   try {
     const conditions = [
       subId && `WHERE sc.id = ${subId}`,
@@ -29,7 +36,14 @@ const getProductsByCondition = async (subId, mainId, pId, isMain) => {
       isMain && `WHERE p.main_product = ${isMain}`,
     ].filter(Boolean);
 
+    const orderings = [
+      orderBy && `ORDER BY ${orderBy}`,
+      sorting && ` ${sorting}`,
+    ].filter(Boolean);
+
     const condition = conditions[0] || '';
+
+    const ordering = orderings.join('') || '';
 
     return await appDataSource.query(
       `SELECT 
@@ -60,7 +74,8 @@ const getProductsByCondition = async (subId, mainId, pId, isMain) => {
         JOIN products_ingredients pig ON pig.ingredient_id = ig.id
         GROUP BY pig.product_id
     ) joined_ig ON joined_ig.pid = p.id        
-    ${condition}`
+    ${condition}
+    ${ordering}`
     );
   } catch (err) {
     err.message = 'DATABASE_ERROR';

--- a/routes/productRouter.js
+++ b/routes/productRouter.js
@@ -3,8 +3,8 @@ const productController = require('../controllers/productController');
 
 const router = express.Router();
 
-router.get('', productController.productSearch);
 router.get('', productController.getProducts);
+router.get('/search', productController.productSearch);
 
 module.exports = {
   router,

--- a/services/productService.js
+++ b/services/productService.js
@@ -4,8 +4,22 @@ const searchProduct = async (keyword) => {
   return productDao.searchProduct(keyword);
 };
 
-const getProductsByCondition = async (subId, mainId, pId, isMain) => {
-  return productDao.getProductsByCondition(subId, mainId, pId, isMain);
+const getProductsByCondition = async (
+  subId,
+  mainId,
+  pId,
+  isMain,
+  orderBy,
+  sorting
+) => {
+  return productDao.getProductsByCondition(
+    subId,
+    mainId,
+    pId,
+    isMain,
+    orderBy,
+    sorting
+  );
 };
 
 module.exports = {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- products의 리스트 GET 요청 시 정렬 기준과 오름차순/내림차순 지정하여 request 보내면 그에 맞게 product list 전송하는 기능 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- products GET 요청과 동일한 url에서 query parameter로 'orderby'와 'sorting'을 보내주면 해당 기준으로 정렬되도록
- 현재는 정렬 기준으로 사용할만한 기준이 price 밖에 없지만, 추후 서비스가 확대되었을 때 여러 기준으로 정렬 가능하도록 구현함
- sorting은 ASC와 DESC 중 입력되어야 하며, sorting 값이 없을 경우 default로 ASC가 적용됨
- category 필터와 동시에 적용 가능 

<br />

## :: 테스트 결과 이미지
![image](https://user-images.githubusercontent.com/120387100/230819649-23fd631a-d929-4368-a2df-d796b9515a8b.png)

<br />

## :: 기타 질문 및 특이 사항